### PR TITLE
Callback 2

### DIFF
--- a/include/plugin/PluginDefinition.h
+++ b/include/plugin/PluginDefinition.h
@@ -19,6 +19,12 @@ struct PluginDefinition
 	QJsonObject     settings;
 };
 
+typedef struct PyEnumDef
+{
+	char* name;
+	int value;
+} PyEnumDef;
+
 enum PluginAction
 {
 	P_INSTALL,
@@ -38,32 +44,9 @@ enum PluginAction
 	P_UPDATED_AVAIL
 };
 
-// type definition for callback enums
- typedef enum
- {
+enum CallbackAction
+{
 	ON_COMP_STATE_CHANGED,
 	ON_SETTINGS_CHANGED,
-	ON_VISIBLE_PRIORITY_CHANGED,
-	CALLBACK_INVALID
- } callback_type_t;
-
-inline const char* callbackTypeToString(int callback)
-{
-	switch (callback)
-	{
-		case ON_COMP_STATE_CHANGED:				return "ON_COMP_STATE_CHANGED";
-		case ON_SETTINGS_CHANGED:				return "ON_SETTINGS_CHANGED";
-		case ON_VISIBLE_PRIORITY_CHANGED:		return "ON_VISIBLE_PRIORITY_CHANGED";
-		default:								return "";
-	}
-}
-
-inline callback_type_t stringToCallbackType(QString string)
-{
-	string = string.toUpper();
-	if (string == "ON_COMP_STATE_CHANGED")			return ON_COMP_STATE_CHANGED;
-	if (string == "ON_SETTINGS_CHANGED")			return ON_SETTINGS_CHANGED;
-	if (string == "ON_VISIBLE_PRIORITY_CHANGED")	return ON_VISIBLE_PRIORITY_CHANGED;
-
-	return CALLBACK_INVALID;
-}
+	ON_VISIBLE_PRIORITY_CHANGED
+};

--- a/include/plugin/PluginModule.h
+++ b/include/plugin/PluginModule.h
@@ -4,6 +4,10 @@
 #include <Python.h>
 #define slots
 
+// hyperion incl
+#include <plugin/PluginDefinition.h>
+
+// qt incl
 #include <QJsonValue>
 
 class Plugin;
@@ -22,6 +26,10 @@ public:
 
 	// json 2 python
 	static PyObject* json2python		(const QJsonValue & jsonData);
+
+	// type definition for callback enums
+	static PyEnumDef callbackEnums[];
+	static PyEnumDef componentsEnums[];
 
 	// Wrapper methods for Python interpreter extra buildin methods
 	static PyMethodDef pluginMethods[];

--- a/libsrc/plugin/Plugin.h
+++ b/libsrc/plugin/Plugin.h
@@ -15,15 +15,6 @@
 #include <QThread>
 #include <QStringList>
 
-class acquireGIL
-{
-public:
-	inline acquireGIL() { state = PyGILState_Ensure(); };
-	inline ~acquireGIL() { PyGILState_Release(state); };
-private:
-	PyGILState_STATE state;
-};
-
 class Hyperion;
 class Plugins;
 class PriorityMuxer;
@@ -50,7 +41,8 @@ public:
 	bool hasRemoveFlag() const { return _remove; };
 
 private:
-	/// The Plugins instance
+	PyThreadState* _state;
+	/// The plugins instance
 	Plugins* _plugins;
 	/// Instance pointer of Hyperion
 	Hyperion* _hyperion;
@@ -150,7 +142,7 @@ public slots:
 
 	///
 	/// @brief called when the visible priorty has changed
-	/// @param comp   the prioriry
+	/// @param priority   the prioriry
 	///
 	void onVisiblePriorityChanged(const quint8& priority);
 };


### PR DESCRIPTION
Also das ist jetzt mein 2 Anlauf die Sache ein wenig bequemer zu gestalten.
Den GIL lock habe ich geändert, damit keine segfaults mehr auftreten wenn du Ketten bilden möchtest.
Der registerCallback() Aufruf wurde erweitert, damit zusätzliche Objekte in einer optionalen Liste übergeben werden können, sowie können jetzt mehrere Callbacks auf das gleiche Event angelegt werden.
Darauf reagiert bis jetzt nur onCompStateChanged() in form einer optionalen Eventliste. Bedeutet kurz gesagt: Der Callback onCompStateChanged() wird nur bei spezifischen Komponenten aufgerufen.

Am besten zeig ich dir wieder die modifizierte [service.py](https://gist.github.com/Paulchen-Panther/1399585f10f83772c7e694518cdb7acc)